### PR TITLE
Fix locale handling for tests (fixes #13)

### DIFF
--- a/de.tototec.cmdoption/src/test/java/de/tototec/cmdoption/ArgPlaceholderTest.java
+++ b/de.tototec.cmdoption/src/test/java/de/tototec/cmdoption/ArgPlaceholderTest.java
@@ -2,13 +2,17 @@ package de.tototec.cmdoption;
 
 import static org.testng.Assert.assertEquals;
 
+
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 
-import de.tobiasroeser.lambdatest.testng.FreeSpec;
+
+import de.tobiasroeser.lambdatest.testng.FreeSpec;import de.tototec.cmdoption.test.TestSupport;
+
 
 public class ArgPlaceholderTest extends FreeSpec {
 
@@ -39,7 +43,9 @@ public class ArgPlaceholderTest extends FreeSpec {
 	{
 		test("description placeholder without any args", () -> {
 			final StringBuilder sb = new StringBuilder();
-			new CmdlineParser(new Config7()).usage(sb);
+			TestSupport.withLocale(Locale.ROOT, () -> {
+				new CmdlineParser(new Config7()).usage(sb);
+			});
 			assertEquals(sb.toString(), "Usage: <main class> [options] [parameter]\n\n"
 					+ "Options:\n"
 					+ "  -a  A\n\n"
@@ -48,7 +54,9 @@ public class ArgPlaceholderTest extends FreeSpec {
 		});
 		test("description unused placeholder with args", () -> {
 			final StringBuilder sb = new StringBuilder();
-			new CmdlineParser(new Config8()).usage(sb);
+			TestSupport.withLocale(Locale.ROOT, () -> {
+				new CmdlineParser(new Config8()).usage(sb);
+			});
 			assertEquals(sb.toString(), "Usage: <main class> [options] [parameter]\n\n"
 					+ "Options:\n"
 					+ "  -a 1  A\n\n"
@@ -57,7 +65,9 @@ public class ArgPlaceholderTest extends FreeSpec {
 		});
 		test("description used placeholder with args", () -> {
 			final StringBuilder sb = new StringBuilder();
-			new CmdlineParser(new Config9()).usage(sb);
+			TestSupport.withLocale(Locale.ROOT, () -> {
+				new CmdlineParser(new Config9()).usage(sb);
+			});
 			assertEquals(sb.toString(), "Usage: <main class> [options] [parameter]\n\n"
 					+ "Options:\n"
 					+ "  -a 1  A with arg 1\n\n"
@@ -67,41 +77,44 @@ public class ArgPlaceholderTest extends FreeSpec {
 
 		test("description used placeholder with args and translation", () -> {
 			final StringBuilder sb = new StringBuilder();
-			final CmdlineParser cp = new CmdlineParser(new Config9());
-			final ResourceBundle rb = new ResourceBundle() {
-				private final Map<String, String> trs = new LinkedHashMap<String, String>() {
-					private static final long serialVersionUID = 1L;
-					{
-						put("1", "one");
-						put("2", "two");
+			TestSupport.withLocale(Locale.ROOT, () -> {
+				final CmdlineParser cp = new CmdlineParser(new Config9());
+
+				final ResourceBundle rb = new ResourceBundle() {
+					private final Map<String, String> trs = new LinkedHashMap<String, String>() {
+						private static final long serialVersionUID = 1L;
+						{
+							put("1", "one");
+							put("2", "two");
+						}
+					};
+
+					@Override
+					protected Object handleGetObject(final String key) {
+						return trs.get(key);
+					}
+
+					@Override
+					public Enumeration<String> getKeys() {
+						final Iterator<String> it = trs.keySet().iterator();
+						return new Enumeration<String>() {
+
+							@Override
+							public boolean hasMoreElements() {
+								return it.hasNext();
+							}
+
+							@Override
+							public String nextElement() {
+								return it.next();
+							}
+
+						};
 					}
 				};
-
-				@Override
-				protected Object handleGetObject(final String key) {
-					return trs.get(key);
-				}
-
-				@Override
-				public Enumeration<String> getKeys() {
-					final Iterator<String> it = trs.keySet().iterator();
-					return new Enumeration<String>() {
-
-						@Override
-						public boolean hasMoreElements() {
-							return it.hasNext();
-						}
-
-						@Override
-						public String nextElement() {
-							return it.next();
-						}
-
-					};
-				}
-			};
-			cp.setResourceBundle(rb);
-			cp.usage(sb);
+				cp.setResourceBundle(rb);
+				cp.usage(sb);
+			});
 			assertEquals(sb.toString(), "Usage: <main class> [options] [parameter]\n\n"
 					+ "Options:\n"
 					+ "  -a one  A with arg one\n\n"

--- a/de.tototec.cmdoption/src/test/java/de/tototec/cmdoption/ArgPlaceholderTest.java
+++ b/de.tototec.cmdoption/src/test/java/de/tototec/cmdoption/ArgPlaceholderTest.java
@@ -2,7 +2,6 @@ package de.tototec.cmdoption;
 
 import static org.testng.Assert.assertEquals;
 
-
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -10,9 +9,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.ResourceBundle;
 
-
-import de.tobiasroeser.lambdatest.testng.FreeSpec;import de.tototec.cmdoption.test.TestSupport;
-
+import de.tobiasroeser.lambdatest.testng.FreeSpec;
+import de.tototec.cmdoption.test.TestSupport;
 
 public class ArgPlaceholderTest extends FreeSpec {
 

--- a/de.tototec.cmdoption/src/test/java/de/tototec/cmdoption/FinalFieldTest.java
+++ b/de.tototec.cmdoption/src/test/java/de/tototec/cmdoption/FinalFieldTest.java
@@ -5,6 +5,8 @@ import java.util.Locale;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import de.tototec.cmdoption.test.TestSupport;
+
 public class FinalFieldTest extends Assert {
 
 	public static class Config {
@@ -25,40 +27,36 @@ public class FinalFieldTest extends Assert {
 	private final String expectedUsage = "Usage: <main class> [options]\n\nOptions:\n  --help true|false  \n";
 	private final String expectedFinalUsage = "Usage: <main class>\n";
 
-	private void assertUsage(final CmdlineParser cp, final String expectedUsage) {
-		final StringBuilder sb = new StringBuilder();
-		final Locale defaultLocale = Locale.getDefault();
-		try {
-			Locale.setDefault(Locale.ROOT);
-			cp.usage(sb);
-		} finally {
-			Locale.setDefault(defaultLocale);
-		}
-		assertEquals(sb.toString(), expectedUsage);
-	}
-
 	@Test
 	public void testField() {
-		final Config config = new Config();
-		final CmdlineParser cp = new CmdlineParser(config);
-		assertUsage(cp, expectedUsage);
-		assertEquals(config.help, false);
-		cp.parse("--help", "false");
-		assertEquals(config.help, false);
-		cp.parse("--help", "true");
-		assertEquals(config.help, true);
+		TestSupport.withLocale(Locale.ROOT, () -> {
+			final Config config = new Config();
+			final CmdlineParser cp = new CmdlineParser(config);
+			final StringBuilder sb = new StringBuilder();
+			cp.usage(sb);
+			assertEquals(sb.toString(), expectedUsage);
+			assertEquals(config.help, false);
+			cp.parse("--help", "false");
+			assertEquals(config.help, false);
+			cp.parse("--help", "true");
+			assertEquals(config.help, true);
+		});
 	}
 
 	@Test
 	public void testFieldWithDefault() {
-		final ConfigWithDefault config = new ConfigWithDefault();
-		final CmdlineParser cp = new CmdlineParser(config);
-		assertUsage(cp, expectedUsage);
-		assertEquals(config.help, false);
-		cp.parse("--help", "false");
-		assertEquals(config.help, false);
-		cp.parse("--help", "true");
-		assertEquals(config.help, true);
+		TestSupport.withLocale(Locale.ROOT, () -> {
+			final ConfigWithDefault config = new ConfigWithDefault();
+			final CmdlineParser cp = new CmdlineParser(config);
+			final StringBuilder sb = new StringBuilder();
+			cp.usage(sb);
+			assertEquals(sb.toString(), expectedUsage);
+			assertEquals(config.help, false);
+			cp.parse("--help", "false");
+			assertEquals(config.help, false);
+			cp.parse("--help", "true");
+			assertEquals(config.help, true);
+		});
 	}
 
 	@Test(expectedExceptions = CmdlineParserException.class)
@@ -70,11 +68,15 @@ public class FinalFieldTest extends Assert {
 
 	@Test(expectedExceptions = CmdlineParserException.class)
 	public void testFinalFieldWithDefaultFail() {
-		final ConfigWithFinalField config = new ConfigWithFinalField();
-		final CmdlineParser cp = new CmdlineParser(config);
-		assertUsage(cp, expectedFinalUsage);
-		assertEquals(config.help, false);
-		cp.parse("--help", "false");
+		TestSupport.withLocale(Locale.ROOT, () -> {
+			final ConfigWithFinalField config = new ConfigWithFinalField();
+			final CmdlineParser cp = new CmdlineParser(config);
+			final StringBuilder sb = new StringBuilder();
+			cp.usage(sb);
+			assertEquals(sb.toString(), expectedUsage);
+			assertEquals(config.help, false);
+			cp.parse("--help", "false");
+		});
 	}
 
 }

--- a/de.tototec.cmdoption/src/test/java/de/tototec/cmdoption/test/TestSupport.java
+++ b/de.tototec.cmdoption/src/test/java/de/tototec/cmdoption/test/TestSupport.java
@@ -1,0 +1,17 @@
+package de.tototec.cmdoption.test;
+
+import java.util.Locale;
+
+public class TestSupport {
+
+	public static void withLocale(final Locale locale, final Runnable r) {
+		final Locale defaultLocale = Locale.getDefault();
+		try {
+			Locale.setDefault(Locale.ROOT);
+			r.run();
+		} finally {
+			Locale.setDefault(defaultLocale);
+		}
+	}
+
+}


### PR DESCRIPTION
Added helper method for executing code within a specified locale and fixed test so that the locale is already respected on CmdlineParser construction. This should fix #13.