### PR TITLE
Support short options with args and without space

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -221,6 +221,37 @@ public class Main {
 
 As you can see, aggregated short options can also have any number of arguments.
 
+=== Short options support argument without a space
+
+If you prefer to set short options with a single argument without any delimiter or space, you can enable that by setting `CmdlineParser.setShortOptionsWithArgsPrefix(String)`.
+You need to give the string, that denotes the start of short options (this is probably a `-`).
+To disable, set `null` or the empty string.
+
+.Example for short options that support their single-arg without a delimiter
+[source,java]
+----
+import de.tototec.cmdoption.CmdOption;
+import de.tototec.cmdoption.CmdlineParser;
+
+public class Config {
+  @CmdOption(names = { "-D", "--define" }, args = { "PROPERTY=VALUE" }, maxCount = -1)
+  List<String> defines = new LinkedList<String>();
+}
+
+public class Main {
+  public static void main(String[] args) {
+    final Config config = new Config();
+    final CmdlineParser cp = new CmdlineParser(config);
+    cp.setShortOptionsWithArgsPrefix("-"); // <1>
+    // demo of parsing aggregated options
+    cp.parse(new String[] { "-DTEST=true" });
+    assert config.defines.get(0).equals("TEST=true");
+  }
+}
+----
+
+WARNING: Enabled both features together with short option aggregation might result in surprising results. Option aggregation will be parsed first.
+
 === Stop parsing options after the first parameter was found
 
 Sometime, you want to parse options only if they come before the first parameter.

--- a/de.tototec.cmdoption/src/test/java/de/tototec/cmdoption/ShortOptionWithTest.java
+++ b/de.tototec.cmdoption/src/test/java/de/tototec/cmdoption/ShortOptionWithTest.java
@@ -1,0 +1,60 @@
+package de.tototec.cmdoption;
+
+import de.tobiasroeser.lambdatest.testng.FreeSpec;
+
+import static de.tobiasroeser.lambdatest.Expect.*;
+
+public class ShortOptionWithTest extends FreeSpec {
+
+	public static class Config {
+		@CmdOption(names = {"-f", "--file"}, args = {"FILE"})
+		String file = null;
+
+		@CmdOption(names = {"-c", "--count"}, args = {"n"})
+		int count = 0;
+	}
+
+	public static class Param {
+		@CmdOption(args = {"PARAMETER"})
+		String param;
+	}
+
+	public ShortOptionWithTest() {
+
+		test("Setting all short options separately should work (reference test)", () -> {
+			final Config config = new Config();
+			final CmdlineParser cp = new CmdlineParser(config);
+			cp.parse(new String[]{"-c", "4", "-f", "file.txt"});
+			expectEquals(config.count, 4);
+			expectEquals(config.file, "file.txt");
+		});
+
+		test("Setting all short options separately should work (when feature is enabled)", () -> {
+			final Config config = new Config();
+			final CmdlineParser cp = new CmdlineParser(config);
+			cp.setShortOptionWithArgsPrefix("-");
+			cp.parse(new String[]{"-c", "4", "-f", "file.txt"});
+			expectEquals(config.count, 4);
+			expectEquals(config.file, "file.txt");
+		});
+
+		test("Short option with arg is not supported when disabled", () -> {
+			final Config config = new Config();
+			final CmdlineParser cp = new CmdlineParser(config);
+			intercept(CmdlineParserException.class, "\\QUnsupported option or parameter found: -c4\\E", () -> {
+				cp.parse(new String[]{"-c4"});
+			});
+		});
+
+		test("Short option with arg should work", () -> {
+			final Config config = new Config();
+			final CmdlineParser cp = new CmdlineParser(config);
+			cp.setShortOptionWithArgsPrefix("-");
+			cp.parse(new String[]{"--CMDOPTION_DEBUG", "-c4", "-ffile.txt"});
+			expectEquals(config.count, 4);
+			expectEquals(config.file, "file.txt");
+		});
+
+	}
+
+}


### PR DESCRIPTION
Disabled by default, allows this feature to set options like the Java `-D` option.
